### PR TITLE
add asyncstorage constants

### DIFF
--- a/shared/actions/authActions.js
+++ b/shared/actions/authActions.js
@@ -13,6 +13,13 @@ import {
 } from '../utils';
 
 const STORAGE_NAME = '@PingoStorage:';
+const STORAGE_KEY = {
+  ACCESS_TOKEN: 'accessToken',
+  REFRESH_TOKEN: 'refreshToken',
+  USER_KEY: 'userKey',
+  SECRET: 'secret',
+  LOGIN_TYPE: 'loginType'
+};
 const STORAGE_KEY_accessToken = 'accessToken';
 const STORAGE_KEY_refreshToken = 'refreshToken';
 const STORAGE_KEY_userKey = 'userKey';


### PR DESCRIPTION
- legacy code has wrapped async storage function like getSomeKey(), SetSomeKey().
- However, I think using constant make it more clear and easy to use async storage with 
- easy to read and consistent style.
- I didn't change any code but only added constants.
- If this pull request is merge, then I'm planning to gradually adopt this style:) 