### PR TITLE
increase heap size in android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
+      android:largeHeap="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
- There was a serious bug that after you take a picture app is down in some android version.
- Turns out it is because of OOM(out of memory).
- It is a remedy, but I've just increased the heap size of our android application.
- we need to consider how to deal images later.
- References
-[https://zeemee.engineering/react-native-on-android-lessons-learned-99fee8f1d390#.hlzr3ri01](https://zeemee.engineering/react-native-on-android-lessons-learned-99fee8f1d390#.hlzr3ri01)