### PR TITLE
Fix alert error

### DIFF
--- a/shared/components/map.js
+++ b/shared/components/map.js
@@ -178,10 +178,10 @@ export default class Map extends Component {
       this.props.setUserLocation(userLocation);
       this.setState({userLocationEnabled: true});
     },
-    (error) => {
+    (err) => {
       Alert.alert(
         'Unable to get your location',
-        error,
+        err.message,
         [
           {text: 'Cancel'}
         ]


### PR DESCRIPTION
We got some error message right after turn on the app.

    2016-12-16 12:46:57.703 [error][tid:main][RCTConvert.m:58] JSON value '{
        "PERMISSION_DENIED" = 1;
        "POSITION_UNAVAILABLE" = 2;
        TIMEOUT = 3;
        code = 2;
        message = "Unable to retrieve location.";
    }' of type NSMutableDictionary cannot be converted to NSString

The reason is the format of JSON and i fixed it.



BTW We need to fix why it cannot detect the location at the first time.
I will jump in that problem.